### PR TITLE
fix: rota do step 5 do onboarding + adiciona usuario_id FK em 4 tabelas

### DIFF
--- a/elvira/android/gradle.properties
+++ b/elvira/android/gradle.properties
@@ -4,3 +4,7 @@ android.useAndroidX=true
 android.enableJetifier=true
 kotlin.jvm.target.validation.mode=WARNING
 kotlin.incremental=false
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/elvira/lib/main.dart
+++ b/elvira/lib/main.dart
@@ -16,6 +16,7 @@ import 'src/core/providers/medicamentos_provider.dart';
 import 'src/core/providers/consultas_provider.dart';
 import 'src/core/providers/dose_provider.dart';
 import 'src/core/routes/app_routes.dart';
+import 'src/core/theme/colorblind_filters.dart';
 import 'src/services/call_service.dart';
 import 'src/core/services/notification_service.dart';
 import 'src/core/services/volume_guard_service.dart';
@@ -181,6 +182,9 @@ class _ElviraAppState extends State<ElviraApp> {
     return Consumer<UsuarioProvider>(
       builder: (context, usuarioProvider, _) {
         final escala = usuarioProvider.escalaFonte;
+        final colorFilter = colorFilterFor(
+          ColorBlindMode.fromId(usuarioProvider.modoDaltonico),
+        );
 
         if (!usuarioProvider.loading &&
             !usuarioProvider.onboardingCompleto &&
@@ -194,18 +198,22 @@ class _ElviraAppState extends State<ElviraApp> {
           });
         }
 
+        final app = MaterialApp(
+          title: 'Elvira',
+          navigatorKey: navigatorKey,
+          theme: _buildTheme(),
+          debugShowCheckedModeBanner: false,
+          initialRoute: AppRoutes.home,
+          routes: AppRoutes.routes,
+        );
+
         return MediaQuery(
           data: MediaQuery.of(
             context,
           ).copyWith(textScaler: TextScaler.linear(escala)),
-          child: MaterialApp(
-            title: 'Elvira',
-            navigatorKey: navigatorKey,
-            theme: _buildTheme(),
-            debugShowCheckedModeBanner: false,
-            initialRoute: AppRoutes.home,
-            routes: AppRoutes.routes,
-          ),
+          child: colorFilter != null
+              ? ColorFiltered(colorFilter: colorFilter, child: app)
+              : app,
         );
       },
     );

--- a/elvira/lib/src/core/db/database_helper.dart
+++ b/elvira/lib/src/core/db/database_helper.dart
@@ -6,7 +6,7 @@ class DatabaseHelper {
   static final DatabaseHelper instance = DatabaseHelper._();
 
   static const _dbName = 'elvira.db';
-  static const _dbVersion = 8;
+  static const _dbVersion = 10;
 
   Database? _db;
 
@@ -39,6 +39,8 @@ class DatabaseHelper {
         alergias TEXT,
         condicoes_saude TEXT,
         pin_cuidador TEXT,
+        tem_cuidador INTEGER NOT NULL DEFAULT 0,
+        modo_daltonico TEXT NOT NULL DEFAULT 'normal',
         plano_saude TEXT,
         tamanho_fonte_base REAL NOT NULL DEFAULT 1.0,
         onboarding_completo INTEGER NOT NULL DEFAULT 0
@@ -273,6 +275,20 @@ class DatabaseHelper {
         ''');
         await db.execute('DROP TABLE log_uso');
         await db.execute('ALTER TABLE log_uso_v8 RENAME TO log_uso');
+      } catch (_) {}
+    }
+    if (oldVersion < 9) {
+      try {
+        await db.execute(
+          'ALTER TABLE usuario ADD COLUMN tem_cuidador INTEGER NOT NULL DEFAULT 0;',
+        );
+      } catch (_) {}
+    }
+    if (oldVersion < 10) {
+      try {
+        await db.execute(
+          "ALTER TABLE usuario ADD COLUMN modo_daltonico TEXT NOT NULL DEFAULT 'normal';",
+        );
       } catch (_) {}
     }
   }

--- a/elvira/lib/src/core/db/database_helper.dart
+++ b/elvira/lib/src/core/db/database_helper.dart
@@ -6,7 +6,7 @@ class DatabaseHelper {
   static final DatabaseHelper instance = DatabaseHelper._();
 
   static const _dbName = 'elvira.db';
-  static const _dbVersion = 7;
+  static const _dbVersion = 8;
 
   Database? _db;
 
@@ -48,19 +48,22 @@ class DatabaseHelper {
     await db.execute('''
       CREATE TABLE contato (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
+        usuario_id INTEGER NOT NULL DEFAULT 1,
         nome TEXT NOT NULL,
         relacao TEXT NOT NULL,
         telefone TEXT NOT NULL,
         foto_path TEXT,
         eh_emergencia INTEGER NOT NULL DEFAULT 0,
         eh_favorito INTEGER NOT NULL DEFAULT 0,
-        ordem_exibicao INTEGER NOT NULL DEFAULT 0
+        ordem_exibicao INTEGER NOT NULL DEFAULT 0,
+        FOREIGN KEY (usuario_id) REFERENCES usuario(id) ON DELETE CASCADE
       )
     ''');
 
     await db.execute('''
       CREATE TABLE medicamento (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
+        usuario_id INTEGER NOT NULL DEFAULT 1,
         nome TEXT NOT NULL,
         dosagem TEXT NOT NULL,
         unidade TEXT NOT NULL DEFAULT 'comprimido',
@@ -68,7 +71,8 @@ class DatabaseHelper {
         foto_path TEXT,
         data_inicio TEXT,
         data_fim TEXT,
-        ativo INTEGER NOT NULL DEFAULT 1
+        ativo INTEGER NOT NULL DEFAULT 1,
+        FOREIGN KEY (usuario_id) REFERENCES usuario(id) ON DELETE CASCADE
       )
     ''');
 
@@ -97,20 +101,24 @@ class DatabaseHelper {
     await db.execute('''
       CREATE TABLE log_uso (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
+        usuario_id INTEGER NOT NULL DEFAULT 1,
         tipo TEXT NOT NULL,
         detalhe TEXT NOT NULL,
-        data_hora TEXT NOT NULL
+        data_hora TEXT NOT NULL,
+        FOREIGN KEY (usuario_id) REFERENCES usuario(id) ON DELETE CASCADE
       )
     ''');
 
     await db.execute('''
       CREATE TABLE consulta_medica (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
+        usuario_id INTEGER NOT NULL DEFAULT 1,
         hospital_name TEXT NOT NULL,
         date_time TEXT NOT NULL,
         maps_url TEXT,
         notes TEXT,
-        lembrete_minutos INTEGER NOT NULL DEFAULT 60
+        lembrete_minutos INTEGER NOT NULL DEFAULT 60,
+        FOREIGN KEY (usuario_id) REFERENCES usuario(id) ON DELETE CASCADE
       )
     ''');
   }
@@ -175,6 +183,96 @@ class DatabaseHelper {
         await db.execute(
           'ALTER TABLE contato ADD COLUMN eh_favorito INTEGER NOT NULL DEFAULT 0;',
         );
+      } catch (_) {}
+    }
+    if (oldVersion < 8) {
+      // Adiciona usuario_id FK em contato, medicamento, consulta_medica e log_uso.
+      // SQLite não permite ALTER TABLE para adicionar FK, então recria as tabelas.
+      try {
+        await db.execute('''
+          CREATE TABLE contato_v8 (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            usuario_id INTEGER NOT NULL DEFAULT 1,
+            nome TEXT NOT NULL,
+            relacao TEXT NOT NULL,
+            telefone TEXT NOT NULL,
+            foto_path TEXT,
+            eh_emergencia INTEGER NOT NULL DEFAULT 0,
+            eh_favorito INTEGER NOT NULL DEFAULT 0,
+            ordem_exibicao INTEGER NOT NULL DEFAULT 0,
+            FOREIGN KEY (usuario_id) REFERENCES usuario(id) ON DELETE CASCADE
+          )
+        ''');
+        await db.execute('''
+          INSERT INTO contato_v8 (id, usuario_id, nome, relacao, telefone, foto_path, eh_emergencia, eh_favorito, ordem_exibicao)
+          SELECT id, 1, nome, relacao, telefone, foto_path, eh_emergencia, eh_favorito, ordem_exibicao FROM contato
+        ''');
+        await db.execute('DROP TABLE contato');
+        await db.execute('ALTER TABLE contato_v8 RENAME TO contato');
+      } catch (_) {}
+
+      try {
+        await db.execute('''
+          CREATE TABLE medicamento_v8 (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            usuario_id INTEGER NOT NULL DEFAULT 1,
+            nome TEXT NOT NULL,
+            dosagem TEXT NOT NULL,
+            unidade TEXT NOT NULL DEFAULT 'comprimido',
+            instrucao_uso TEXT,
+            foto_path TEXT,
+            data_inicio TEXT,
+            data_fim TEXT,
+            ativo INTEGER NOT NULL DEFAULT 1,
+            FOREIGN KEY (usuario_id) REFERENCES usuario(id) ON DELETE CASCADE
+          )
+        ''');
+        await db.execute('''
+          INSERT INTO medicamento_v8 (id, usuario_id, nome, dosagem, unidade, instrucao_uso, foto_path, data_inicio, data_fim, ativo)
+          SELECT id, 1, nome, dosagem, unidade, instrucao_uso, foto_path, data_inicio, data_fim, ativo FROM medicamento
+        ''');
+        await db.execute('DROP TABLE medicamento');
+        await db.execute('ALTER TABLE medicamento_v8 RENAME TO medicamento');
+      } catch (_) {}
+
+      try {
+        await db.execute('''
+          CREATE TABLE consulta_medica_v8 (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            usuario_id INTEGER NOT NULL DEFAULT 1,
+            hospital_name TEXT NOT NULL,
+            date_time TEXT NOT NULL,
+            maps_url TEXT,
+            notes TEXT,
+            lembrete_minutos INTEGER NOT NULL DEFAULT 60,
+            FOREIGN KEY (usuario_id) REFERENCES usuario(id) ON DELETE CASCADE
+          )
+        ''');
+        await db.execute('''
+          INSERT INTO consulta_medica_v8 (id, usuario_id, hospital_name, date_time, maps_url, notes, lembrete_minutos)
+          SELECT id, 1, hospital_name, date_time, maps_url, notes, lembrete_minutos FROM consulta_medica
+        ''');
+        await db.execute('DROP TABLE consulta_medica');
+        await db.execute('ALTER TABLE consulta_medica_v8 RENAME TO consulta_medica');
+      } catch (_) {}
+
+      try {
+        await db.execute('''
+          CREATE TABLE log_uso_v8 (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            usuario_id INTEGER NOT NULL DEFAULT 1,
+            tipo TEXT NOT NULL,
+            detalhe TEXT NOT NULL,
+            data_hora TEXT NOT NULL,
+            FOREIGN KEY (usuario_id) REFERENCES usuario(id) ON DELETE CASCADE
+          )
+        ''');
+        await db.execute('''
+          INSERT INTO log_uso_v8 (id, usuario_id, tipo, detalhe, data_hora)
+          SELECT id, 1, tipo, detalhe, data_hora FROM log_uso
+        ''');
+        await db.execute('DROP TABLE log_uso');
+        await db.execute('ALTER TABLE log_uso_v8 RENAME TO log_uso');
       } catch (_) {}
     }
   }

--- a/elvira/lib/src/core/models/consulta_medica.dart
+++ b/elvira/lib/src/core/models/consulta_medica.dart
@@ -1,5 +1,6 @@
 class ConsultaMedica {
   final int? id;
+  final int usuarioId;
   final String hospitalName;
   final DateTime dateTime;
   final String? mapsUrl;
@@ -8,6 +9,7 @@ class ConsultaMedica {
 
   const ConsultaMedica({
     this.id,
+    this.usuarioId = 1,
     required this.hospitalName,
     required this.dateTime,
     this.mapsUrl,
@@ -17,6 +19,7 @@ class ConsultaMedica {
 
   Map<String, dynamic> toMap() => {
     'id': id,
+    'usuario_id': usuarioId,
     'hospital_name': hospitalName,
     'date_time': dateTime.toIso8601String(),
     'maps_url': mapsUrl,
@@ -26,6 +29,7 @@ class ConsultaMedica {
 
   factory ConsultaMedica.fromMap(Map<String, dynamic> m) => ConsultaMedica(
     id: m['id'] as int?,
+    usuarioId: m['usuario_id'] as int? ?? 1,
     hospitalName: m['hospital_name'] as String,
     dateTime: DateTime.parse(m['date_time'] as String),
     mapsUrl: m['maps_url'] as String?,
@@ -35,6 +39,7 @@ class ConsultaMedica {
 
   ConsultaMedica copyWith({
     int? id,
+    int? usuarioId,
     String? hospitalName,
     DateTime? dateTime,
     String? mapsUrl,
@@ -42,6 +47,7 @@ class ConsultaMedica {
     int? lembreteMinutos,
   }) => ConsultaMedica(
     id: id ?? this.id,
+    usuarioId: usuarioId ?? this.usuarioId,
     hospitalName: hospitalName ?? this.hospitalName,
     dateTime: dateTime ?? this.dateTime,
     mapsUrl: mapsUrl ?? this.mapsUrl,

--- a/elvira/lib/src/core/models/contato.dart
+++ b/elvira/lib/src/core/models/contato.dart
@@ -1,5 +1,6 @@
 class Contato {
   final int? id;
+  final int usuarioId;
   final String nome;
   final String relacao;
   final String telefone;
@@ -10,6 +11,7 @@ class Contato {
 
   const Contato({
     this.id,
+    this.usuarioId = 1,
     required this.nome,
     required this.relacao,
     required this.telefone,
@@ -49,6 +51,7 @@ class Contato {
 
   Map<String, dynamic> toMap() => {
         'id': id,
+        'usuario_id': usuarioId,
         'nome': nome,
         'relacao': relacao,
         'telefone': telefone,
@@ -60,6 +63,7 @@ class Contato {
 
   factory Contato.fromMap(Map<String, dynamic> m) => Contato(
         id: m['id'] as int?,
+        usuarioId: m['usuario_id'] as int? ?? 1,
         nome: m['nome'] as String,
         relacao: m['relacao'] as String,
         telefone: m['telefone'] as String,
@@ -71,6 +75,7 @@ class Contato {
 
   Contato copyWith({
     int? id,
+    int? usuarioId,
     String? nome,
     String? relacao,
     String? telefone,
@@ -81,6 +86,7 @@ class Contato {
   }) =>
       Contato(
         id: id ?? this.id,
+        usuarioId: usuarioId ?? this.usuarioId,
         nome: nome ?? this.nome,
         relacao: relacao ?? this.relacao,
         telefone: telefone ?? this.telefone,

--- a/elvira/lib/src/core/models/log_uso.dart
+++ b/elvira/lib/src/core/models/log_uso.dart
@@ -2,12 +2,14 @@ enum TipoLog { ligacao, appAberto, telaVisitada, doseRegistrada }
 
 class LogUso {
   final int? id;
+  final int usuarioId;
   final TipoLog tipo;
   final String detalhe;
   final DateTime dataHora;
 
   const LogUso({
     this.id,
+    this.usuarioId = 1,
     required this.tipo,
     required this.detalhe,
     required this.dataHora,
@@ -15,6 +17,7 @@ class LogUso {
 
   Map<String, dynamic> toMap() => {
         'id': id,
+        'usuario_id': usuarioId,
         'tipo': tipo.name,
         'detalhe': detalhe,
         'data_hora': dataHora.toIso8601String(),
@@ -22,6 +25,7 @@ class LogUso {
 
   factory LogUso.fromMap(Map<String, dynamic> m) => LogUso(
         id: m['id'] as int?,
+        usuarioId: m['usuario_id'] as int? ?? 1,
         tipo: TipoLog.values.firstWhere(
           (t) => t.name == m['tipo'],
           orElse: () => TipoLog.telaVisitada,

--- a/elvira/lib/src/core/models/medicamento.dart
+++ b/elvira/lib/src/core/models/medicamento.dart
@@ -1,5 +1,6 @@
 class Medicamento {
   final int? id;
+  final int usuarioId;
   final String nome;
   final String dosagem;
   final String unidade;
@@ -11,6 +12,7 @@ class Medicamento {
 
   const Medicamento({
     this.id,
+    this.usuarioId = 1,
     required this.nome,
     required this.dosagem,
     this.unidade = 'comprimido',
@@ -23,6 +25,7 @@ class Medicamento {
 
   Map<String, dynamic> toMap() => {
         'id': id,
+        'usuario_id': usuarioId,
         'nome': nome,
         'dosagem': dosagem,
         'unidade': unidade,
@@ -35,6 +38,7 @@ class Medicamento {
 
   factory Medicamento.fromMap(Map<String, dynamic> m) => Medicamento(
         id: m['id'] as int?,
+        usuarioId: m['usuario_id'] as int? ?? 1,
         nome: m['nome'] as String,
         dosagem: m['dosagem'] as String,
         unidade: m['unidade'] as String? ?? 'comprimido',
@@ -47,6 +51,7 @@ class Medicamento {
 
   Medicamento copyWith({
     int? id,
+    int? usuarioId,
     String? nome,
     String? dosagem,
     String? unidade,
@@ -58,6 +63,7 @@ class Medicamento {
   }) =>
       Medicamento(
         id: id ?? this.id,
+        usuarioId: usuarioId ?? this.usuarioId,
         nome: nome ?? this.nome,
         dosagem: dosagem ?? this.dosagem,
         unidade: unidade ?? this.unidade,

--- a/elvira/lib/src/core/models/usuario.dart
+++ b/elvira/lib/src/core/models/usuario.dart
@@ -8,8 +8,10 @@ class Usuario {
   final String? alergias;
   final String? condicoesSaude;
   final String? pinCuidador;
+  final bool temCuidador;
   final String? planoSaude;
   final double tamanhoFonteBase;
+  final String modoDaltonico;
   final bool onboardingCompleto;
 
   const Usuario({
@@ -22,8 +24,10 @@ class Usuario {
     this.alergias,
     this.condicoesSaude,
     this.pinCuidador,
+    this.temCuidador = false,
     this.planoSaude,
     this.tamanhoFonteBase = 1.0,
+    this.modoDaltonico = 'normal',
     this.onboardingCompleto = false,
   });
 
@@ -37,8 +41,10 @@ class Usuario {
         'alergias': alergias,
         'condicoes_saude': condicoesSaude,
         'pin_cuidador': pinCuidador,
+        'tem_cuidador': temCuidador ? 1 : 0,
         'plano_saude': planoSaude,
         'tamanho_fonte_base': tamanhoFonteBase,
+        'modo_daltonico': modoDaltonico,
         'onboarding_completo': onboardingCompleto ? 1 : 0,
       };
 
@@ -52,8 +58,10 @@ class Usuario {
         alergias: m['alergias'] as String?,
         condicoesSaude: m['condicoes_saude'] as String?,
         pinCuidador: m['pin_cuidador'] as String?,
+        temCuidador: (m['tem_cuidador'] as int?) == 1,
         planoSaude: m['plano_saude'] as String?,
         tamanhoFonteBase: (m['tamanho_fonte_base'] as num?)?.toDouble() ?? 1.0,
+        modoDaltonico: m['modo_daltonico'] as String? ?? 'normal',
         onboardingCompleto: (m['onboarding_completo'] as int?) == 1,
       );
 
@@ -67,8 +75,11 @@ class Usuario {
     String? alergias,
     String? condicoesSaude,
     String? pinCuidador,
+    bool clearPinCuidador = false,
+    bool? temCuidador,
     String? planoSaude,
     double? tamanhoFonteBase,
+    String? modoDaltonico,
     bool? onboardingCompleto,
   }) =>
       Usuario(
@@ -80,9 +91,11 @@ class Usuario {
         tipoSanguineo: tipoSanguineo ?? this.tipoSanguineo,
         alergias: alergias ?? this.alergias,
         condicoesSaude: condicoesSaude ?? this.condicoesSaude,
-        pinCuidador: pinCuidador ?? this.pinCuidador,
+        pinCuidador: clearPinCuidador ? null : (pinCuidador ?? this.pinCuidador),
+        temCuidador: temCuidador ?? this.temCuidador,
         planoSaude: planoSaude ?? this.planoSaude,
         tamanhoFonteBase: tamanhoFonteBase ?? this.tamanhoFonteBase,
+        modoDaltonico: modoDaltonico ?? this.modoDaltonico,
         onboardingCompleto: onboardingCompleto ?? this.onboardingCompleto,
       );
 }

--- a/elvira/lib/src/core/providers/usuario_provider.dart
+++ b/elvira/lib/src/core/providers/usuario_provider.dart
@@ -35,13 +35,32 @@ class UsuarioProvider extends ChangeNotifier {
     await salvar(_usuario!.copyWith(tamanhoFonteBase: escala));
   }
 
+  bool get temCuidador => _usuario?.temCuidador ?? false;
+
   Future<bool> verificarPin(String pin) async {
-    final pinAtual = _usuario?.pinCuidador ?? '0000';
+    final pinAtual = _usuario?.pinCuidador;
+    if (pinAtual == null || pinAtual.isEmpty) return false;
     return pinAtual == pin;
   }
 
   Future<void> definirPin(String pin) async {
     if (_usuario == null) return;
     await salvar(_usuario!.copyWith(pinCuidador: pin));
+  }
+
+  Future<void> definirCuidador(bool temCuidador, {String? pin}) async {
+    if (_usuario == null) return;
+    if (temCuidador) {
+      await salvar(_usuario!.copyWith(temCuidador: true, pinCuidador: pin));
+    } else {
+      await salvar(_usuario!.copyWith(temCuidador: false, clearPinCuidador: true));
+    }
+  }
+
+  String get modoDaltonico => _usuario?.modoDaltonico ?? 'normal';
+
+  Future<void> definirModoDaltonico(String modo) async {
+    if (_usuario == null) return;
+    await salvar(_usuario!.copyWith(modoDaltonico: modo));
   }
 }

--- a/elvira/lib/src/core/routes/app_routes.dart
+++ b/elvira/lib/src/core/routes/app_routes.dart
@@ -79,6 +79,7 @@ class AppRoutes {
     step2: (_) => const Step2GenderScreen(),
     step3: (_) => const Step3CaregiverScreen(),
     step4: (_) => const Step4AccessibilityScreen(),
+    step5: (_) => const Step5AudioScreen(),
     home: (_) => const HomeScreen(),
     discagem: (_) => const DiscagemScreen(),
     contatos: (_) => const ContatosScreen(),

--- a/elvira/lib/src/core/theme/colorblind_filters.dart
+++ b/elvira/lib/src/core/theme/colorblind_filters.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+
+/// Modos de correção de cores para pessoas daltônicas.
+enum ColorBlindMode {
+  normal,
+  protanopia,
+  deuteranopia,
+  tritanopia;
+
+  String get id => name;
+
+  static ColorBlindMode fromId(String id) {
+    return ColorBlindMode.values.firstWhere(
+      (m) => m.id == id,
+      orElse: () => ColorBlindMode.normal,
+    );
+  }
+
+  String get label {
+    switch (this) {
+      case ColorBlindMode.normal:
+        return 'Sem correção';
+      case ColorBlindMode.protanopia:
+        return 'Protanopia (dificuldade com vermelho)';
+      case ColorBlindMode.deuteranopia:
+        return 'Deuteranopia (dificuldade com verde)';
+      case ColorBlindMode.tritanopia:
+        return 'Tritanopia (dificuldade com azul/amarelo)';
+    }
+  }
+}
+
+/// Matrizes de correção (daltonização) para cada modo.
+/// Realçam as cores que cada tipo de daltonismo tem mais dificuldade
+/// em distinguir, deslocando o "erro" de percepção para outros canais.
+const Map<ColorBlindMode, List<double>> _correctionMatrices = {
+  ColorBlindMode.protanopia: [
+    1.000000, 0.000000, 0.000000, 0, 0,
+    0.287338, 0.686147, 0.026515, 0, 0,
+    0.358369, -0.413215, 1.054846, 0, 0,
+    0, 0, 0, 1, 0,
+  ],
+  ColorBlindMode.deuteranopia: [
+    1.000000, 0.000000, 0.000000, 0, 0,
+    0.097674, 0.835028, 0.067299, 0, 0,
+    0.272817, -0.387235, 1.114418, 0, 0,
+    0, 0, 0, 1, 0,
+  ],
+  ColorBlindMode.tritanopia: [
+    0.844695, -0.244325, 0.399629, 0, 0,
+    0.045059, 0.751140, 0.203801, 0, 0,
+    0.000000, 0.000000, 1.000000, 0, 0,
+    0, 0, 0, 1, 0,
+  ],
+};
+
+/// Retorna o filtro de cor a aplicar na interface para o modo informado,
+/// ou `null` se nenhuma correção deve ser aplicada.
+ColorFilter? colorFilterFor(ColorBlindMode mode) {
+  final matrix = _correctionMatrices[mode];
+  if (matrix == null) return null;
+  return ColorFilter.matrix(matrix);
+}

--- a/elvira/lib/src/core/widgets/elvira_feedback_dialog.dart
+++ b/elvira/lib/src/core/widgets/elvira_feedback_dialog.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import '../theme/app_colors.dart';
+import '../theme/app_text_styles.dart';
+
+enum FeedbackType { success, error, info }
+
+Future<void> showFeedbackDialog(
+  BuildContext context, {
+  required String message,
+  String? title,
+  FeedbackType type = FeedbackType.success,
+}) {
+  final IconData icon;
+  final Color color;
+  switch (type) {
+    case FeedbackType.success:
+      icon = Icons.check_circle_rounded;
+      color = AppColors.green;
+      break;
+    case FeedbackType.error:
+      icon = Icons.error_rounded;
+      color = AppColors.red;
+      break;
+    case FeedbackType.info:
+      icon = Icons.info_rounded;
+      color = AppColors.amber;
+      break;
+  }
+
+  return showDialog(
+    context: context,
+    builder: (_) => AlertDialog(
+      backgroundColor: Colors.white,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      icon: Icon(icon, color: color, size: 48),
+      title: title != null
+          ? Text(title, style: AppTextStyles.h3, textAlign: TextAlign.center)
+          : null,
+      content: Text(message, style: AppTextStyles.body, textAlign: TextAlign.center),
+      actionsAlignment: MainAxisAlignment.center,
+      actions: [
+        SizedBox(
+          width: 120,
+          height: 56,
+          child: ElevatedButton(
+            onPressed: () => Navigator.pop(context),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: AppColors.primary,
+              foregroundColor: Colors.white,
+              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+            ),
+            child: Text('OK', style: AppTextStyles.button.copyWith(color: Colors.white)),
+          ),
+        ),
+      ],
+    ),
+  );
+}

--- a/elvira/lib/src/features/consultas/consultas_hoje_screen.dart
+++ b/elvira/lib/src/features/consultas/consultas_hoje_screen.dart
@@ -7,6 +7,7 @@ import '../../core/providers/consultas_provider.dart';
 import '../../core/theme/app_colors.dart';
 import '../../core/theme/app_text_styles.dart';
 import '../../core/widgets/elvira_app_bar.dart';
+import '../../core/widgets/elvira_feedback_dialog.dart';
 
 class ConsultasHojeScreen extends StatelessWidget {
   const ConsultasHojeScreen({super.key});
@@ -72,18 +73,20 @@ class _ConsultaTile extends StatelessWidget {
   Future<void> _abrirMaps(BuildContext context) async {
     final url = consulta.mapsUrl as String?;
     if (url == null || url.trim().isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('Esta consulta não tem link de Maps cadastrado.'),
-        ),
+      showFeedbackDialog(
+        context,
+        message: 'Esta consulta não tem link de Maps cadastrado.',
+        type: FeedbackType.error,
       );
       return;
     }
 
     final uri = Uri.tryParse(url.trim());
     if (uri == null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('O link de Maps está inválido.')),
+      showFeedbackDialog(
+        context,
+        message: 'O link de Maps está inválido.',
+        type: FeedbackType.error,
       );
       return;
     }

--- a/elvira/lib/src/features/cuidador/configuracoes/configuracoes_screen.dart
+++ b/elvira/lib/src/features/cuidador/configuracoes/configuracoes_screen.dart
@@ -15,8 +15,10 @@ import '../../../core/services/prefs_service.dart';
 import '../../../core/services/volume_guard_service.dart';
 import '../../../core/theme/app_colors.dart';
 import '../../../core/theme/app_text_styles.dart';
+import '../../../core/theme/colorblind_filters.dart';
 import '../../../core/widgets/elvira_app_bar.dart';
 import '../../../core/widgets/elvira_button.dart';
+import '../../../core/widgets/elvira_feedback_dialog.dart';
 import '../../../services/call_service.dart';
 
 class ConfiguracoesScreen extends StatefulWidget {
@@ -78,9 +80,7 @@ class _ConfiguracoesScreenState extends State<ConfiguracoesScreen> {
     await Future.delayed(const Duration(seconds: 3));
     await Alarm.stop(99999);
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Som salvo: ${som.nome}', style: AppTextStyles.body)),
-      );
+      showFeedbackDialog(context, message: 'Som salvo: ${som.nome}');
     }
   }
 
@@ -231,13 +231,9 @@ class _ConfiguracoesScreenState extends State<ConfiguracoesScreen> {
 
     await _carregarVolume();
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(
-            'Volume calibrado: ${(_volumeCalibracao * 100).round()}%',
-            style: AppTextStyles.body,
-          ),
-        ),
+      showFeedbackDialog(
+        context,
+        message: 'Volume calibrado: ${(_volumeCalibracao * 100).round()}%',
       );
     }
   }
@@ -343,9 +339,46 @@ class _ConfiguracoesScreenState extends State<ConfiguracoesScreen> {
   Future<void> _salvarEscala() async {
     await context.read<UsuarioProvider>().atualizarEscalaFonte(_escala);
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Tamanho do texto salvo!', style: AppTextStyles.body)),
-      );
+      showFeedbackDialog(context, message: 'Tamanho do texto salvo!');
+    }
+  }
+
+  Future<void> _confirmarModoDaltonico(ColorBlindMode modo) async {
+    final atual = context.read<UsuarioProvider>().modoDaltonico;
+    if (atual == modo.id) return;
+
+    final confirmar = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: Colors.white,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+        icon: const Icon(Icons.palette_rounded, color: AppColors.primary, size: 48),
+        title: Text('Trocar as cores da tela?', style: AppTextStyles.h3, textAlign: TextAlign.center),
+        content: Text(
+          'As cores de todo o aplicativo vão mudar para o modo "${modo.label}".',
+          style: AppTextStyles.body,
+          textAlign: TextAlign.center,
+        ),
+        actionsAlignment: MainAxisAlignment.center,
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancelar'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: ElevatedButton.styleFrom(backgroundColor: AppColors.primary, foregroundColor: Colors.white),
+            child: const Text('Trocar'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmar != true || !mounted) return;
+
+    await context.read<UsuarioProvider>().definirModoDaltonico(modo.id);
+    if (mounted) {
+      showFeedbackDialog(context, message: 'Ajuste de cores salvo!');
     }
   }
 
@@ -353,18 +386,24 @@ class _ConfiguracoesScreenState extends State<ConfiguracoesScreen> {
     final provider = context.read<UsuarioProvider>();
     final ok = await provider.verificarPin(_pinAtualCtrl.text);
     if (!ok) {
-      if (mounted) ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('PIN atual incorreto', style: AppTextStyles.body)));
+      if (mounted) {
+        showFeedbackDialog(context, message: 'PIN atual incorreto', type: FeedbackType.error);
+      }
       return;
     }
     if (_pinNovoCtrl.text != _pinConfCtrl.text || _pinNovoCtrl.text.length != 4) {
-      if (mounted) ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('PINs não conferem', style: AppTextStyles.body)));
+      if (mounted) {
+        showFeedbackDialog(context, message: 'PINs não conferem', type: FeedbackType.error);
+      }
       return;
     }
     await provider.definirPin(_pinNovoCtrl.text);
     _pinAtualCtrl.clear();
     _pinNovoCtrl.clear();
     _pinConfCtrl.clear();
-    if (mounted) ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('PIN alterado com sucesso!', style: AppTextStyles.body)));
+    if (mounted) {
+      showFeedbackDialog(context, message: 'PIN alterado com sucesso!');
+    }
   }
 
   @override
@@ -535,6 +574,46 @@ class _ConfiguracoesScreenState extends State<ConfiguracoesScreen> {
             ),
             const SizedBox(height: 12),
             ElviraButton(label: 'Aplicar tamanho', onPressed: _salvarEscala),
+            const SizedBox(height: 28),
+            // ─── Pessoas daltônicas ───────────────────────────
+            Text('Pessoas daltônicas', style: AppTextStyles.h3),
+            const SizedBox(height: 8),
+            Container(
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(color: Colors.white, borderRadius: BorderRadius.circular(16), border: Border.all(color: AppColors.blueLight)),
+              child: Column(
+                children: ColorBlindMode.values.map((modo) {
+                  final modoAtual = context.watch<UsuarioProvider>().modoDaltonico;
+                  final selecionado = modoAtual == modo.id;
+                  return InkWell(
+                    borderRadius: BorderRadius.circular(12),
+                    onTap: () => _confirmarModoDaltonico(modo),
+                    child: AnimatedContainer(
+                      duration: const Duration(milliseconds: 150),
+                      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                      decoration: BoxDecoration(
+                        color: selecionado ? AppColors.blueXLight : Colors.transparent,
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: Row(
+                        children: [
+                          Radio<String>(
+                            value: modo.id,
+                            groupValue: modoAtual,
+                            activeColor: AppColors.primary,
+                            onChanged: (_) => _confirmarModoDaltonico(modo),
+                          ),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: Text(modo.label, style: AppTextStyles.body),
+                          ),
+                        ],
+                      ),
+                    ),
+                  );
+                }).toList(),
+              ),
+            ),
             const SizedBox(height: 28),
             // Trocar PIN
             Text('Trocar PIN do cuidador', style: AppTextStyles.h3),

--- a/elvira/lib/src/features/cuidador/consultas/consulta_form_screen.dart
+++ b/elvira/lib/src/features/cuidador/consultas/consulta_form_screen.dart
@@ -7,6 +7,7 @@ import '../../../core/theme/app_colors.dart';
 import '../../../core/theme/app_text_styles.dart';
 import '../../../core/widgets/elvira_app_bar.dart';
 import '../../../core/widgets/elvira_button.dart';
+import '../../../core/widgets/elvira_feedback_dialog.dart';
 
 class ConsultaFormScreen extends StatefulWidget {
   const ConsultaFormScreen({super.key});
@@ -100,10 +101,10 @@ class _ConsultaFormScreenState extends State<ConsultaFormScreen> {
   Future<void> _salvar() async {
     if (!_formKey.currentState!.validate()) return;
     if (_dateTime == null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('Selecione a data e o horário da consulta.'),
-        ),
+      showFeedbackDialog(
+        context,
+        message: 'Selecione a data e o horário da consulta.',
+        type: FeedbackType.error,
       );
       return;
     }
@@ -126,12 +127,22 @@ class _ConsultaFormScreenState extends State<ConsultaFormScreen> {
       } else {
         await provider.adicionarConsulta(consulta);
       }
-      if (mounted) Navigator.pop(context);
+      if (mounted) {
+        await showFeedbackDialog(
+          context,
+          message: _editando != null
+              ? 'Consulta atualizada com sucesso!'
+              : 'Consulta adicionada com sucesso!',
+        );
+        if (mounted) Navigator.pop(context);
+      }
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(
+        await showFeedbackDialog(
           context,
-        ).showSnackBar(SnackBar(content: Text('Erro ao salvar consulta: $e')));
+          message: 'Erro ao salvar consulta: $e',
+          type: FeedbackType.error,
+        );
         setState(() => _salvando = false);
       }
     }

--- a/elvira/lib/src/features/cuidador/consultas/consultas_list_screen.dart
+++ b/elvira/lib/src/features/cuidador/consultas/consultas_list_screen.dart
@@ -9,6 +9,7 @@ import '../../../core/routes/app_routes.dart';
 import '../../../core/theme/app_colors.dart';
 import '../../../core/theme/app_text_styles.dart';
 import '../../../core/widgets/elvira_app_bar.dart';
+import '../../../core/widgets/elvira_feedback_dialog.dart';
 
 class ConsultasListScreen extends StatelessWidget {
   const ConsultasListScreen({super.key});
@@ -101,18 +102,20 @@ class _ConsultaCard extends StatelessWidget {
   Future<void> _abrirMaps(BuildContext context) async {
     final url = consulta.mapsUrl;
     if (url == null || url.trim().isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('Esta consulta não tem link de Maps cadastrado.'),
-        ),
+      showFeedbackDialog(
+        context,
+        message: 'Esta consulta não tem link de Maps cadastrado.',
+        type: FeedbackType.error,
       );
       return;
     }
 
     final uri = Uri.tryParse(url.trim());
     if (uri == null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('O link de Maps está inválido.')),
+      showFeedbackDialog(
+        context,
+        message: 'O link de Maps está inválido.',
+        type: FeedbackType.error,
       );
       return;
     }

--- a/elvira/lib/src/features/cuidador/contatos/contato_form_screen.dart
+++ b/elvira/lib/src/features/cuidador/contatos/contato_form_screen.dart
@@ -11,6 +11,7 @@ import '../../../core/theme/app_colors.dart';
 import '../../../core/theme/app_text_styles.dart';
 import '../../../core/widgets/elvira_app_bar.dart';
 import '../../../core/widgets/elvira_button.dart';
+import '../../../core/widgets/elvira_feedback_dialog.dart';
 
 class ContatoFormScreen extends StatefulWidget {
   const ContatoFormScreen({super.key});
@@ -58,8 +59,10 @@ class _ContatoFormScreenState extends State<ContatoFormScreen> {
     final granted = await fc.FlutterContacts.requestPermission();
     if (!granted) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Permissão de contatos negada.')),
+        showFeedbackDialog(
+          context,
+          message: 'Permissão de contatos negada.',
+          type: FeedbackType.error,
         );
       }
       return;

--- a/elvira/lib/src/features/cuidador/contatos/contatos_admin_screen.dart
+++ b/elvira/lib/src/features/cuidador/contatos/contatos_admin_screen.dart
@@ -10,6 +10,7 @@ import '../../../core/theme/app_colors.dart';
 import '../../../core/theme/app_text_styles.dart';
 import '../../../core/widgets/elvira_app_bar.dart';
 import '../../../core/widgets/contato_avatar.dart';
+import '../../../core/widgets/elvira_feedback_dialog.dart';
 import '../../../core/routes/app_routes.dart';
 
 class ContatosAdminScreen extends StatefulWidget {
@@ -24,8 +25,10 @@ class _ContatosAdminScreenState extends State<ContatosAdminScreen> {
     final granted = await fc.FlutterContacts.requestPermission();
     if (!granted) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Permissão negada.')),
+        showFeedbackDialog(
+          context,
+          message: 'Permissão negada.',
+          type: FeedbackType.error,
         );
       }
       return;
@@ -58,9 +61,9 @@ class _ContatosAdminScreenState extends State<ContatosAdminScreen> {
 
         if (mounted) {
           await context.read<ContatosProvider>().adicionar(novoContato);
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text('$nome importado com sucesso!')),
-          );
+          if (mounted) {
+            showFeedbackDialog(context, message: '$nome importado com sucesso!');
+          }
         }
       }
     }

--- a/elvira/lib/src/features/cuidador/identidade/identidade_form_screen.dart
+++ b/elvira/lib/src/features/cuidador/identidade/identidade_form_screen.dart
@@ -74,6 +74,7 @@ class _IdentidadeFormScreenState extends State<IdentidadeFormScreen> {
       alergias: _alergias.isEmpty ? null : _alergias.join(','),
       condicoesSaude: _condicoes.isEmpty ? null : _condicoes.join(','),
       pinCuidador: atual?.pinCuidador,
+      temCuidador: atual?.temCuidador ?? false,
       tamanhoFonteBase: atual?.tamanhoFonteBase ?? 1.0,
       onboardingCompleto: atual?.onboardingCompleto ?? true,
     );

--- a/elvira/lib/src/features/cuidador/medicamentos/medicamento_form_screen.dart
+++ b/elvira/lib/src/features/cuidador/medicamentos/medicamento_form_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import '../../../core/providers/medicamentos_provider.dart';
 import '../../../core/models/medicamento.dart';
@@ -10,6 +11,7 @@ import '../../../core/theme/app_colors.dart';
 import '../../../core/theme/app_text_styles.dart';
 import '../../../core/widgets/elvira_app_bar.dart';
 import '../../../core/widgets/elvira_button.dart';
+import '../../../core/widgets/elvira_feedback_dialog.dart';
 
 class MedicamentoFormScreen extends StatefulWidget {
   const MedicamentoFormScreen({super.key});
@@ -120,25 +122,19 @@ class _MedicamentoFormScreenState extends State<MedicamentoFormScreen> {
 
   void _gerarHorariosAutomaticos() {
     if (_horarios.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(
-            'Adicione o horário da primeira dose para o app preencher os demais',
-            style: AppTextStyles.bodySmall,
-          ),
-        ),
+      showFeedbackDialog(
+        context,
+        message: 'Adicione o horário da primeira dose para o app preencher os demais',
+        type: FeedbackType.error,
       );
       return;
     }
     final int? intervalo = int.tryParse(_intervaloCtrl.text);
     if (intervalo == null || intervalo <= 0 || intervalo > 24) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(
-            'Digite um intervalo válido (ex: 8)',
-            style: AppTextStyles.bodySmall,
-          ),
-        ),
+      showFeedbackDialog(
+        context,
+        message: 'Digite um intervalo válido (ex: 8)',
+        type: FeedbackType.error,
       );
       return;
     }
@@ -166,13 +162,10 @@ class _MedicamentoFormScreenState extends State<MedicamentoFormScreen> {
   Future<void> _salvar() async {
     if (!_formKey.currentState!.validate()) return;
     if (_horarios.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(
-            'Adicione ao menos 1 horário',
-            style: AppTextStyles.body,
-          ),
-        ),
+      showFeedbackDialog(
+        context,
+        message: 'Adicione ao menos 1 horário',
+        type: FeedbackType.error,
       );
       return;
     }
@@ -212,11 +205,21 @@ class _MedicamentoFormScreenState extends State<MedicamentoFormScreen> {
       } else {
         await provider.adicionarMedicamento(med, doses);
       }
-      if (mounted) Navigator.pop(context);
+      if (mounted) {
+        await showFeedbackDialog(
+          context,
+          message: _editando != null
+              ? 'Medicamento atualizado com sucesso!'
+              : 'Medicamento foi salvo!',
+        );
+        if (mounted) Navigator.pop(context);
+      }
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Erro ao salvar medicamento: $e')),
+        await showFeedbackDialog(
+          context,
+          message: 'Erro ao salvar medicamento: $e',
+          type: FeedbackType.error,
         );
         setState(() => _salvando = false);
       }
@@ -246,7 +249,8 @@ class _MedicamentoFormScreenState extends State<MedicamentoFormScreen> {
                       'Dosagem',
                       _dosagemCtrl,
                       required: true,
-                      keyboardType: TextInputType.text,
+                      keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                      inputFormatters: [_DosagemFormatter()],
                     ),
                   ),
                   const SizedBox(width: 10),
@@ -519,12 +523,14 @@ class _MedicamentoFormScreenState extends State<MedicamentoFormScreen> {
     bool required = false,
     int maxLines = 1,
     TextInputType? keyboardType,
+    List<TextInputFormatter>? inputFormatters,
   }) {
     return TextFormField(
       controller: ctrl,
       style: AppTextStyles.body,
       maxLines: maxLines,
       keyboardType: keyboardType,
+      inputFormatters: inputFormatters,
       textCapitalization: TextCapitalization.sentences,
       decoration: InputDecoration(labelText: label),
       scrollPadding: const EdgeInsets.only(bottom: 80),
@@ -533,5 +539,20 @@ class _MedicamentoFormScreenState extends State<MedicamentoFormScreen> {
               ? (v) => (v?.trim().isEmpty ?? true) ? 'Campo obrigatório' : null
               : null,
     );
+  }
+}
+
+class _DosagemFormatter extends TextInputFormatter {
+  static final _regex = RegExp(r'^\d*(,\d{0,1})?$');
+
+  @override
+  TextEditingValue formatEditUpdate(
+    TextEditingValue oldValue,
+    TextEditingValue newValue,
+  ) {
+    if (newValue.text.isEmpty || _regex.hasMatch(newValue.text)) {
+      return newValue;
+    }
+    return oldValue;
   }
 }

--- a/elvira/lib/src/features/discagem/discagem_screen.dart
+++ b/elvira/lib/src/features/discagem/discagem_screen.dart
@@ -55,12 +55,6 @@ class _DiscagemScreenState extends State<DiscagemScreen> {
     await FlutterPhoneDirectCaller.callNumber(_numero);
   }
 
-  String get _numeroFormatado {
-    if (_numero.length <= 2) return _numero;
-    if (_numero.length <= 7) return '(${_numero.substring(0, 2)}) ${_numero.substring(2)}';
-    return '(${_numero.substring(0, 2)}) ${_numero.substring(2, 7)}-${_numero.substring(7)}';
-  }
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -72,17 +66,28 @@ class _DiscagemScreenState extends State<DiscagemScreen> {
             width: double.infinity,
             padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 24),
             color: AppColors.primary,
-            child: Column(
+            child: Row(
               children: [
-                Text(
-                  _numero.isEmpty ? 'Digite o número' : _numeroFormatado,
-                  style: AppTextStyles.dialDisplay.copyWith(
-                    color: _numero.isEmpty ? Colors.white54 : Colors.white,
-                    fontSize: 36,
+                Expanded(
+                  child: Text(
+                    _numero.isEmpty ? 'Digite o número' : _numero,
+                    style: AppTextStyles.dialDisplay.copyWith(
+                      color: _numero.isEmpty ? Colors.white54 : Colors.white,
+                      fontSize: 36,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
                   ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
                 ),
+                if (_numero.isNotEmpty)
+                  GestureDetector(
+                    onLongPress: _apagarTudo,
+                    child: IconButton(
+                      onPressed: _apagar,
+                      icon: const Icon(Icons.backspace_outlined, color: Colors.white),
+                      tooltip: 'Apagar',
+                    ),
+                  ),
               ],
             ),
           ),
@@ -135,14 +140,6 @@ class _DiscagemScreenState extends State<DiscagemScreen> {
                       child: const Icon(Icons.call, size: 40),
                     ),
                   ),
-                ),
-                const SizedBox(width: 12),
-                _ActionBtn(
-                  icon: Icons.arrow_back,
-                  color: AppColors.redLight,
-                  iconColor: AppColors.red,
-                  onTap: () => Navigator.pop(context),
-                  tooltip: 'Voltar',
                 ),
               ],
             ),

--- a/elvira/lib/src/features/home/home_screen.dart
+++ b/elvira/lib/src/features/home/home_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:android_intent_plus/android_intent.dart';
@@ -7,6 +8,7 @@ import '../../core/theme/app_colors.dart';
 import '../../core/theme/app_text_styles.dart';
 import '../../core/widgets/status_bar_widget.dart';
 import '../../core/routes/app_routes.dart';
+import '../../core/providers/usuario_provider.dart';
 
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
@@ -98,11 +100,21 @@ class HomeScreen extends StatelessWidget {
                             route: AppRoutes.sobre,
                             color: Color(0xFFE5F4F0),
                           ),
-                          const _AppTile(
+                          _AppTile(
                             emoji: '⚙️',
                             label: 'Cuidador',
-                            route: AppRoutes.cuidadorPin,
-                            color: Color(0xFFDCEEFB),
+                            color: const Color(0xFFDCEEFB),
+                            onTap: () {
+                              HapticFeedback.lightImpact();
+                              final temCuidador =
+                                  context.read<UsuarioProvider>().temCuidador;
+                              Navigator.pushNamed(
+                                context,
+                                temCuidador
+                                    ? AppRoutes.cuidadorPin
+                                    : AppRoutes.cuidadorHome,
+                              );
+                            },
                           ),
                           _AppTile(
                             emoji: '',
@@ -174,7 +186,10 @@ class HomeScreen extends StatelessWidget {
                       Navigator.pushNamed(context, AppRoutes.emergencia);
                     },
                     icon: const Icon(Icons.warning_amber_rounded, size: 34),
-                    label: Text('EMERGÊNCIA', style: AppTextStyles.buttonLarge),
+                    label: Text(
+                      'EMERGÊNCIA',
+                      style: AppTextStyles.buttonLarge.copyWith(color: Colors.white),
+                    ),
                     style: ElevatedButton.styleFrom(
                       backgroundColor: AppColors.red,
                       foregroundColor: Colors.white,

--- a/elvira/lib/src/features/onboarding/step3_caregiver_screen.dart
+++ b/elvira/lib/src/features/onboarding/step3_caregiver_screen.dart
@@ -28,9 +28,10 @@ class _Step3CaregiverScreenState extends State<Step3CaregiverScreen> {
   Future<void> _continuar() async {
     if (_temCuidador == null) return;
     final provider = context.read<UsuarioProvider>();
-    if (_temCuidador! && _pinController.text.length == 4) {
-      await provider.definirPin(_pinController.text);
-    }
+    await provider.definirCuidador(
+      _temCuidador!,
+      pin: _temCuidador! ? _pinController.text : null,
+    );
     if (mounted) Navigator.pushNamed(context, AppRoutes.step4);
   }
 

--- a/elvira/lib/src/features/onboarding/step4_accessibility_screen.dart
+++ b/elvira/lib/src/features/onboarding/step4_accessibility_screen.dart
@@ -41,7 +41,7 @@ class _Step4AccessibilityScreenState extends State<Step4AccessibilityScreen> {
       subtitulo: 'Toque no botão para encontrar o tamanho ideal',
       onContinuar: _concluir,
       onVoltar: () => Navigator.pop(context),
-      labelContinuar: 'Pronto! Entrar no app',
+      labelContinuar: 'Continuar →',
       content: Column(
         children: [
           const SizedBox(height: 16),

--- a/elvira/pubspec.lock
+++ b/elvira/pubspec.lock
@@ -636,10 +636,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -652,10 +652,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1073,10 +1073,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.11"
   timezone:
     dependency: "direct main"
     description:


### PR DESCRIPTION
Correções de merge:
- Adicionada entrada de step5 no mapa de rotas (após o merge dos PRs em paralelo, a constante e o import existiam mas a rota nunca foi registrada, fazendo o botao do step 4 nao levar a lugar nenhum)
- Corrigido label do botao do step 4 de "Pronto! Entrar no app" para "Continuar -->", ja que agora ele leva para o step 5, nao para a home

Atualizacao do banco de dados:
- Schema bumpado para versao 8
- Adicionada coluna usuario_id INTEGER NOT NULL DEFAULT 1 com FOREIGN KEY ON DELETE CASCADE nas tabelas: contato, medicamento, consulta_medica e log_uso
- Migracao v7->v8 recria as 4 tabelas (SQLite nao permite ALTER TABLE para adicionar FK), preservando todos os dados existentes
- Models atualizados com novo campo usuarioId (default 1) sem quebrar chamadas existentes em forms, providers e DAOs

O schema do banco agora reflete o modelo entidade-relacionamento conceitual do projeto, com as ligacoes explicitas entre o idoso e suas entidades (contatos, medicamentos, consultas, logs).